### PR TITLE
Fix: Coverages for React

### DIFF
--- a/src/DocCoverage/DocCoverageUtils/propTypesCoverageReact.js
+++ b/src/DocCoverage/DocCoverageUtils/propTypesCoverageReact.js
@@ -47,7 +47,7 @@ class PropTypesCoverageReact {
       ];
       if (parentKey === astConstants.INIT) {
         if (grandParentValue.id.name) {
-          uniquePush(propsArr, grandParentValue.id.name);
+          // uniquePush(propsArr, grandParentValue.id.name);
         } else {
           grandParentValue.id.properties.forEach((p) =>
             uniquePush(propsArr, p.key?.name || p.value?.name)

--- a/src/DocCoverage/index.js
+++ b/src/DocCoverage/index.js
@@ -104,21 +104,23 @@ class DocumentationCoverage {
           numOfPropTypesDefined += totalPropsLength - missingPropTypesLength;
           return {
             hasStory: false,
+            totalPropCount: totalPropsLength,
             hasAllPropTypes: totalPropsLength
               ? missingPropTypesLength === 0
-              : false,
+              : true,
+            missingPropCount: missingPropTypesLength,
             componentType: isClassComponent ? 'Class Based' : 'Functional',
             missingPropTypes:
               totalPropsLength && totalPropsLength !== missingPropTypesLength
                 ? missingPropTypes
-                : 'No PropTypes Found',
+                : [],
             coverage: `${
               totalPropsLength
                 ? getCoveragePercentage(
                     totalPropsLength - missingPropTypesLength,
                     totalPropsLength
                   )
-                : 0
+                : 100
             }%`,
           };
         }


### PR DESCRIPTION
Hello to the maintainers of this repo 👋
(@shivani-sharechat @sachan-sharechat  @sanjeevyadavIT)

I know this library has been marked as deprecated, but recently, I was tasked to write a report for how 'documented' our React app was, and I resorted to using this tool as I thought it was most fit for our use-case.

I'm making this pull request to hopefully resolve the following issues for getting coverage for React:

### Component's name being a required definition in prop types

For example, we have a simple Component defined as:

```
import PropTypes from 'prop-types';
import React from 'react';

interface Props {
  active: boolean;
  testProp: string;
}

const MyTestProp = (props: Props) => {
  const { active, testProp } = props;
  return (
    <span>Hello</span>
  );
};

MyTestProp.propTypes = {
  active: PropTypes.bool.isRequired,
  testProp: PropTypes.string.isRequired,
};

export default MyTestProp;
```

doc-coverage apparently says `MyTestProp` is missing from the defined `propTypes`. I'm not sure we want to define an unnecessary prop type with the component's name everytime, so I thought we should remove it instead.

Please let me know if my understanding is wrong in any way 🙇 

### Components with no props are not being considered "covered"

When a component has no props (say the same component as above, except it's defined as something like `const MyTestProp = (props: Props)`), doc-coverage will say that it has 0% coverage, and is not included in the count for `componentsWithStoriesOrPropTypes`.

